### PR TITLE
Load DialogGen in 4bit to make usage on 24gb consumer GPUs possible.

### DIFF
--- a/dialoggen/dialoggen_demo.py
+++ b/dialoggen/dialoggen_demo.py
@@ -53,7 +53,7 @@ def load_images(image_files):
 def init_dialoggen_model(model_path, model_base=None):
     model_name = get_model_name_from_path(model_path)
     tokenizer, model, image_processor, context_len = load_pretrained_model(
-        model_path, model_base, model_name, llava_type_model=True)
+        model_path, model_base, model_name, llava_type_model=True, load_4bit=True)
     return {"tokenizer": tokenizer,
             "model": model,
             "image_processor": image_processor}


### PR DESCRIPTION
This alters the DialogGen loading to use bitsandbytes 4bit quantization. This reduces overall memory usage and makes inference possible on 24gb consumer GPUs with DialogGen enabled.