### PR TITLE
Multiple GPUs support and XPU device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,12 +283,20 @@ python app/hydit_app.py --infer-mode fa
 # The enhancement will be unavailable until you restart the app without the `--no-enhance` flag. 
 python app/hydit_app.py --no-enhance
 
+# You can specify the device for HunyuanDiT inference and DialogGen inference respectively,
+# with `--device` and `--enhance-device` flag.
+python app/hydit_app.py --device cuda:0 --enhance-device cuda:1
+python app/hydit_app.py --device xpu:0 --enhance-device xpu:1 # Intel GPU
+
 # Start with English UI
 python app/hydit_app.py --lang en
 
 # Start a multi-turn T2I generation UI. 
 # If your GPU memory is less than 32GB, use '--load-4bit' to enable 4-bit quantization, which requires at least 22GB of memory.
 python app/multiTurnT2I_app.py
+# Using multiple GPU devices.
+python app/multiTurnT2I_app.py --device cuda:0 --enhance-device cuda:1 --load-4bit
+python app/multiTurnT2I_app.py --device xpu:0 --enhance-device xpu:1 --load-4bit # Intel GPU
 ```
 Then the demo can be accessed through http://0.0.0.0:443
 

--- a/dialoggen/llava/model/builder.py
+++ b/dialoggen/llava/model/builder.py
@@ -17,16 +17,19 @@ import os
 import warnings
 import shutil
 
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig, BitsAndBytesConfig
+import transformers
+from transformers import AutoTokenizer, AutoConfig, BitsAndBytesConfig
 import torch
 from llava.model import *
 from llava.constants import DEFAULT_IMAGE_PATCH_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN
 
 
 def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda", use_flash_attn=False, llava_type_model=True, **kwargs):
+    AutoModelForCausalLM = transformers.AutoModelForCausalLM
     if "xpu" in device and (load_8bit or load_4bit):
         try:
-            from ipex_llm.transformers import AutoModelForCausalLM
+            import ipex_llm.transformers
+            AutoModelForCausalLM = ipex_llm.transformers.AutoModelForCausalLM
         except ImportError:
             raise ImportError("""Please install the ipex_llm package to load 8bit/4bit models on XPU.
     pip install --pre ipex-llm[xpu]""")

--- a/hydit/config.py
+++ b/hydit/config.py
@@ -26,12 +26,14 @@ def get_args(default_args=None):
     parser.add_argument("--cfg-scale", type=float, default=6.0, help="Guidance scale for classifier-free.")
 
     # Prompt enhancement
+    parser.add_argument("--enhance-device", type=str, default="cuda", help="Device for DialogGen model inference.")
     parser.add_argument("--enhance", action="store_true", help="Enhance prompt with dialoggen.")
     parser.add_argument("--no-enhance", dest="enhance", action="store_false")
     parser.add_argument("--load-4bit", help="load DialogGen model with 4bit quantization.", action="store_true")
     parser.set_defaults(enhance=True)
 
     # Diffusion
+    parser.add_argument("--device", type=str, default="cuda", help="Device for diffusion model inference")
     parser.add_argument("--learn-sigma", action="store_true", help="Learn extra channels for sigma.")
     parser.add_argument("--no-learn-sigma", dest="learn_sigma", action="store_false")
     parser.set_defaults(learn_sigma=True)

--- a/hydit/inference.py
+++ b/hydit/inference.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
+try:
+    import intel_extension_for_pytorch as ipex
+except ImportError:
+    ipex = None
 
 # For reproducibility
 # torch.backends.cudnn.benchmark = False
@@ -159,7 +163,7 @@ class End2End(object):
         logger.info(f"Got text-to-image model root path: {t2i_root_path}")
 
         # Set device and disable gradient
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = args.device
         torch.set_grad_enabled(False)
         # Disable BertModel logging checkpoint info
         tf_logger.setLevel('ERROR')
@@ -179,7 +183,7 @@ class End2End(object):
         # ========================================================================
         logger.info(f"Loading T5 Text Encoder and T5 Tokenizer...")
         t5_text_encoder_path = self.root / 'mt5'
-        embedder_t5 = MT5Embedder(t5_text_encoder_path, torch_dtype=torch.float16, max_length=256)
+        embedder_t5 = MT5Embedder(t5_text_encoder_path, torch_dtype=torch.float16, max_length=256).to(self.device)
         self.embedder_t5 = embedder_t5
         logger.info(f"Loading t5_text_encoder and t5_tokenizer finished")
 

--- a/sample_t2i.py
+++ b/sample_t2i.py
@@ -19,7 +19,7 @@ def inferencer():
     # Try to enhance prompt
     if args.enhance:
         logger.info("Loading DialogGen model (for prompt enhancement)...")
-        enhancer = DialogGen(str(models_root_path / "dialoggen"), args.load_4bit)
+        enhancer = DialogGen(str(models_root_path / "dialoggen"), device=args.enhance_device, load_4bit=args.load_4bit)
         logger.info("DialogGen model loaded.")
     else:
         enhancer = None


### PR DESCRIPTION
- Adds two new options `--device` and `--enhance-device` to specify devices for HunyuanDiT and DialogGen respectively. Users with multiple GPU devices could offload two models to different devices.
- Supports XPU device provided by [IPEX](https://github.com/intel/intel-extension-for-pytorch).
- Supports DialogGen 4-bit inference on XPU device with [IPEX-LLM](https://github.com/intel-analytics/ipex-llm).

HunyuanDiT inference speed is ~2s/it on Intel Arc A770 16G at resolution 1024x1024.

A demo running multi-turn t2i generation with Intel Arc A770 16G (for HunyuanDiT) + Intel Arc A750 8G (for DialogGen):

```python .\app\multiTurnT2I_app.py --device xpu:0 --enhance-device xpu:1 --load-4bit```

https://github.com/Tencent/HunyuanDiT/assets/7253534/aa9f8d9f-70b5-4b30-8772-581b24f3fc87

