### PR TITLE
feat: Add Compatibility for Windows

### DIFF
--- a/hydit/config.py
+++ b/hydit/config.py
@@ -4,7 +4,7 @@ from .constants import *
 from .modules.models import HUNYUAN_DIT_CONFIG, HUNYUAN_DIT_MODELS
 from .diffusion.gaussian_diffusion import ModelVarType
 
-import deepspeed
+# import deepspeed
 
 def model_var_type(value):
     try:
@@ -182,15 +182,32 @@ def get_args(default_args=None):
     # ========================================================================================================
     # Deepspeed config
     # ========================================================================================================
-    parser = deepspeed.add_config_arguments(parser)
-    parser.add_argument('--local_rank', type=int, default=None,
-                        help='local rank passed from distributed launcher.')
-    parser.add_argument('--deepspeed-optimizer', action='store_true',
-                        help='Switching to the optimizers in DeepSpeed')
-    parser.add_argument('--remote-device', type=str, default='none', choices=['none', 'cpu', 'nvme'],
-                        help='Remote device for ZeRO-3 initialized parameters.')
-    parser.add_argument('--zero-stage', type=int, default=1)
-    parser.add_argument("--async-ema", action="store_true", help="Whether to use multi stream to excut EMA.")
+    # parser = deepspeed.add_config_arguments(parser)
+    # parser.add_argument('--local_rank', type=int, default=None,
+    #                     help='local rank passed from distributed launcher.')
+    # parser.add_argument('--deepspeed-optimizer', action='store_true',
+    #                     help='Switching to the optimizers in DeepSpeed')
+    # parser.add_argument('--remote-device', type=str, default='none', choices=['none', 'cpu', 'nvme'],
+    #                     help='Remote device for ZeRO-3 initialized parameters.')
+    # parser.add_argument('--zero-stage', type=int, default=1)
+    # parser.add_argument("--async-ema", action="store_true", help="Whether to use multi stream to excut EMA.")
+
+        # Attempt to import DeepSpeed and add its arguments if available
+    try:
+        import deepspeed
+
+        # Add DeepSpeed-specific arguments
+        parser = deepspeed.add_config_arguments(parser)
+        parser.add_argument('--local_rank', type=int, default=None,
+                            help='local rank passed from distributed launcher.')
+        parser.add_argument('--deepspeed-optimizer', action='store_true',
+                            help='Switching to the optimizers in DeepSpeed')
+        parser.add_argument('--remote-device', type=str, default='none', choices=['none', 'cpu', 'nvme'],
+                            help='Remote device for ZeRO-3 initialized parameters.')
+        parser.add_argument('--zero-stage', type=int, default=1)
+        parser.add_argument("--async-ema", action="store_true", help="Whether to use multi stream to excut EMA.")
+    except ImportError:
+        print("DeepSpeed not available. Skipping related arguments...")
 
     args = parser.parse_args(default_args)
 

--- a/hydit/modules/models.py
+++ b/hydit/modules/models.py
@@ -201,7 +201,7 @@ class HunYuanDiT(ModelMixin, ConfigMixin, PeftAdapterMixin):
         self.text_len_t5 = args.text_len_t5
         self.norm = args.norm
 
-        use_flash_attn = args.infer_mode == 'fa' or args.use_flash_attn
+        use_flash_attn = args.infer_mode == 'fa' or getattr(args, 'use_flash_attn', False)
         if use_flash_attn:
             log_fn(f"    Enable Flash Attention.")
         qk_norm = args.qk_norm  # See http://arxiv.org/abs/2302.05442 for details.

--- a/sample_t2i.py
+++ b/sample_t2i.py
@@ -1,11 +1,8 @@
 from pathlib import Path
-
 from loguru import logger
-
 from dialoggen.dialoggen_demo import DialogGen
 from hydit.config import get_args
 from hydit.inference import End2End
-
 
 def inferencer():
     args = get_args()
@@ -26,6 +23,15 @@ def inferencer():
 
     return args, gen, enhancer
 
+def get_next_index(save_dir):
+    all_files = list(save_dir.glob('*.png'))
+    indices = []
+    for f in all_files:
+        try:
+            indices.append(int(f.stem))
+        except ValueError:
+            logger.warning(f"Skipping file with non-integer name: {f}")
+    return max(indices, default=-1) + 1
 
 if __name__ == "__main__":
     args, gen, enhancer = inferencer()
@@ -59,12 +65,9 @@ if __name__ == "__main__":
     # Save images
     save_dir = Path('results')
     save_dir.mkdir(exist_ok=True)
+
     # Find the first available index
-    all_files = list(save_dir.glob('*.png'))
-    if all_files:
-        start = max([int(f.stem) for f in all_files]) + 1
-    else:
-        start = 0
+    start = get_next_index(save_dir)
 
     for idx, pil_img in enumerate(images):
         save_path = save_dir / f"{idx + start}.png"


### PR DESCRIPTION
### Windows?
**feat: Add Compatibility for Windows**

### Description
This pull request introduces several changes to ensure compatibility with Windows and the most recent versions of various modules. The following modifications have been made:

1. **Module Upgrades**:
   - Upgraded most modules to their latest versions, including `torch`, `diffusers`, etc.

2. **Downgrade NumPy**:
   - Downgraded NumPy to a version below 2.0.0 to avoid compatibility issues with modules compiled using NumPy 1.x.
     ```sh
     pip install "numpy<2.0.0"
     ```

3. **Conditional Import and Usage of `deepspeed`**:
   - Added a try-except block to conditionally import `deepspeed` and add its related arguments only if `deepspeed` is available.
   - This avoids potential `ImportError` and makes the script more robust.

4. **Enhance Image-Saving Logic**:
   - Introduced the `get_next_index` function to handle non-integer filenames during the image-saving process.
   - This change ensures that the script can handle filenames that do not conform to an integer pattern without breaking.

### Installation Instructions
1. **Clone the Repository**:
    ```sh
    git clone https://github.com/tencent/HunyuanDiT
    cd HunyuanDiT
    ```

2. **Install Dependencies**:

    #### Using a Virtual Environment
    ```sh
    python -m venv venv
    venv\Scripts\activate
    pip install "huggingface_hub[cli]"
    mkdir ckpts
    huggingface-cli download Tencent-Hunyuan/HunyuanDiT --local-dir ./ckpts

    python.exe -m pip install --upgrade pip

    pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu121   
    pip install loguru
    pip install diffusers
    pip install transformers
    pip install timm
    pip install einops
    pip install peft
    pip install sentencepiece
    pip install protobuf
    pip install "numpy<2.0.0"    
    ```

    **Note**: These versions are not the ones used in the `requirements.txt`, but they allow the use of CUDA 12.1 and the newest versions of `diffusers` and `pytorch`. (Same as ComfyUI I believe)

    #### Using Conda for Closer Compatibility with Original Repository
    ```sh
    conda create -n HunyuanDit python=3.9 -c conda-forge -y
    conda activate HunyuanDit

    # Install CUDA 11.7 from conda-forge
    conda install cudatoolkit=11.7 -c conda-forge

    set CUDA_HOME=%CONDA_PREFIX%
    set PATH=%CUDA_HOME%\bin;%PATH%

    python -m pip install --upgrade pip
    pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu117
    pip install loguru==0.7.2
    pip install diffusers==0.21.2
    pip install timm==0.9.5
    pip install einops==0.7.0
    pip install transformers==4.39.1
    pip install peft==0.10.0
    pip install "numpy<2.0"
    pip install sentencepiece==0.1.99
    pip install setuptools==65.5.1
    pip install protobuf==3.19.0
    pip install wheel
    pip install packaging
    ```
3. **Run Inference**:
    ```sh
    python sample_t2i.py --prompt "a woman" --no-enhance
    ```

# WHY?
- Standard install leads to instructions on main repo leads to:

### Error Encountered
- **NumPy Compatibility**:
    ```
    A module that was compiled using NumPy 1.x cannot be run in NumPy 2.0.0 as it may crash. To support both 1.x and 2.x versions of NumPy, modules must be compiled with NumPy 2.0. Some modules may need to rebuild instead e.g. with 'pybind11>=2.12'.
    ```
- **Missing Modules**:
    - `flash_attn`: No module named 'flash_attn'
    - `deepspeed`: No module named 'deepspeed'

### Solution
1. **Downgrade NumPy**:
    ```sh
    pip install "numpy<2.0.0"
    ```

2. **Changes in `hydit/modules/models.py`**:
    ```python
    use_flash_attn = args.infer_mode == 'fa' or getattr(args, 'use_flash_attn', False)
    ```
    - **Explanation**: This function call attempts to access `args.use_flash_attn`. If the attribute does not exist, it returns `False` instead of raising an `AttributeError`. This maintains the intended behavior without causing an error.

3. **Changes in `hydit/config.py`**:
    ```python
    try:
        import deepspeed

        # Add DeepSpeed-specific arguments
        parser = deepspeed.add_config_arguments(parser)
        parser.add_argument('--local_rank', type=int, default=None,
                            help='local rank passed from distributed launcher.')
        parser.add_argument('--deepspeed-optimizer', action='store_true',
                            help='Switching to the optimizers in DeepSpeed')
        parser.add_argument('--remote-device', type=str, default='none', choices=['none', 'cpu', 'nvme'],
                            help='Remote device for ZeRO-3 initialized parameters.')
        parser.add_argument('--zero-stage', type=int, default=1)
        parser.add_argument("--async-ema", action="store_true", help="Whether to use multi stream to excut EMA.")
    except ImportError:
        print("DeepSpeed not available. Skipping related arguments...")
    ```
    - **Explanation**: Added a try-except block to conditionally import `deepspeed` and add its related arguments only if `deepspeed` is available. This ensures that `deepspeed` related arguments are only included when `deepspeed` is successfully imported, avoiding potential `ImportError` and making the script more robust.

4. **Changes in `sample_t2i.py`**:
    ```python
    def get_next_index(save_dir):
        all_files = list(save_dir.glob('*.png'))
        indices = []
        for f in all_files:
            try:
                indices.append(int(f.stem))
            except ValueError:
                logger.warning(f"Skipping file with non-integer name: {f}")
        return max(indices, default=-1) + 1

    # Find the first available index
    start = get_next_index(save_dir)
    ```
    - **Explanation**: Introduced the `get_next_index` function to handle non-integer filenames gracefully during the image-saving process. This ensures that the script can handle filenames that do not conform to an integer pattern without breaking.

### Testing
- **Only tested inference with**:
    ```sh
    python sample_t2i.py --prompt "a picture" --no-enhance
    ```

### Known Bugs
- `deepspeed` and `flash_attn` are currently not supported and training is not supported. 
