### PR TITLE
fix mt5 forward

### DIFF
--- a/hydit/modules/text_encoder.py
+++ b/hydit/modules/text_encoder.py
@@ -76,7 +76,7 @@ class MT5Embedder(nn.Module):
         return text_encoder_embs, text_tokens_and_mask["attention_mask"].to(self.device)
 
     @torch.no_grad()
-    def __call__(self, tokens, attention_mask, layer_index=-1):
+    def forward(self, tokens, attention_mask, layer_index=-1):
         with torch.cuda.amp.autocast():
             outputs = self.model(
                 input_ids=tokens,


### PR DESCRIPTION
在 PyTorch 中，nn.Module类既实现了__call__方法也有forward方法。一般情况下，在自定义的神经网络模块中，应该在forward方法中定义前向传播的逻辑，而不是直接在__call__方法中实现前向传播。