### PR TITLE
[Acceleration with Skip-Cache] Accelerating the inference of Hunyuan-DiT 2x for free with its skip-branches .

### DIFF
--- a/hydit/config.py
+++ b/hydit/config.py
@@ -207,6 +207,9 @@ def get_args(default_args=None):
     parser.add_argument("--gradient-checkpointing", action="store_true", help="Use gradient checkpointing.")
     parser.add_argument("--cpu-offloading", action="store_true", help="Use cpu offloading for parameters and optimizer states.")
     parser.add_argument("--save-optimizer-state", action="store_true", help="Save optimizer state in the checkpoint.")
+    parser.add_argument("--use-cache", action="store_true", help="Accelerate with skip-cahce. This is a training-free caching method which can accelerate Hunyuan-DiT at most 2x for free.")
+    parser.add_argument("--cache-step", type=int, default=2, choices=[2, 3, 4, 5, 6], help="Specify steps to cache using skip-cache for a 1.5x~2.1x speedup.")
+    
 
     # ========================================================================================================
     # Deepspeed config


### PR DESCRIPTION
Hi, I'm the first author of the paper [Accelerating Vision Diffusion Transformers with Skip Branches](https://arxiv.org/abs/2411.17616). In this work, we proposed **Skip-DiT** and **Skip-Cache**. Skip-DiT demonstrates superior feature smoothness and improved training efficiency, while Skip-Cache achieves a 2x acceleration during inference. Notably, Skip-DiT is inspired by Hunyuan-DiT, making it particularly well-suited for integration with Hunyuan-DiT. **We successfully accelerated Hunyuan-DiT inference by 1.5x without any quality degradation and achieved up to 2.0x acceleration with minimal overhead.**

Additionally, **Skip-Cache** **can be integrated into Hunyuan-DiT with just 30+ lines of code**. We have added it to our forked repository, complete with detailed code comments and a consistent coding style for easy adoption. We believe that integrating Skip-Cache into this exceptional model will be highly beneficial. To run the inference with skip-cache with the command line, you only need to add `--use-cache` and specify the `--cache-step`
```shell
python sample_t2i.py --infer-mode fa --prompt "渔舟唱晚" --use-cache --cache-step 2 # or 3,4,5,6
```

Below, we present both quantitative and qualitative results of Skip-Cache on Hunyuan-DiT to showcase its performance.

**Qualitative Results**
![image](https://github.com/user-attachments/assets/a911b229-01e0-451a-a1b3-cc06c2fa33e7)

**Visualizations**
**Comparison between Skip-Cache and other caching methods on HunyuanDiT:**
![image](https://github.com/user-attachments/assets/5d50785b-286e-4dc5-a831-90c2b5d672df)
**Accelerating HunyuanDiT with 2x speedup:**
![image](https://github.com/user-attachments/assets/60bb1f78-0e38-4363-9c5e-b48678ee5181)

