### PR TITLE
fix: preserve input dtype instead of hardcoding float16 in attention layers

### DIFF
--- a/hydit/modules/attn_layers.py
+++ b/hydit/modules/attn_layers.py
@@ -192,8 +192,8 @@ class FlashSelfMHAModified(nn.Module):
         qkv = self.Wqkv(x)
         qkv = qkv.view(b, s, 3, self.num_heads, self.head_dim)  # [b, s, 3, h, d]
         q, k, v = qkv.unbind(dim=2)  # [b, s, h, d]
-        q = self.q_norm(q).half()  # [b, s, h, d]
-        k = self.k_norm(k).half()
+        q = self.q_norm(q).to(x.dtype)  # [b, s, h, d]
+        k = self.k_norm(k).to(x.dtype)
 
         # Apply RoPE if needed
         if freqs_cis_img is not None:
@@ -292,8 +292,8 @@ class FlashCrossMHAModified(nn.Module):
             b, s2, 2, self.num_heads, self.head_dim
         )  # [b, s2, 2, h, d]
         k, v = kv.unbind(dim=2)  # [b, s2, h, d]
-        q = self.q_norm(q).half()  # [b, s1, h, d]
-        k = self.k_norm(k).half()  # [b, s2, h, d]
+        q = self.q_norm(q).to(x.dtype)  # [b, s1, h, d]
+        k = self.k_norm(k).to(x.dtype)  # [b, s2, h, d]
 
         # Apply RoPE if needed
         if freqs_cis_img is not None:
@@ -311,7 +311,7 @@ class FlashCrossMHAModified(nn.Module):
                 b, s3, 2, self.num_heads, self.head_dim
             )
             k_2, v_2 = kv_2.unbind(dim=2)  # [b, s, h, d]
-            k_2 = self.k_norm_ip_adapter(k_2).half()
+            k_2 = self.k_norm_ip_adapter(k_2).to(x.dtype)
             kv_2 = torch.stack([k_2, v_2], dim=2)
             context_2 = self.inner_attn(q, kv_2)
             context_2 = context_2.view(b, s1, -1)
@@ -446,7 +446,7 @@ class CrossAttention(nn.Module):
 
             attn_2 = q @ k_2
 
-            attn_2 = attn_2.softmax(dim=-1).half()
+            attn_2 = attn_2.softmax(dim=-1).to(x.dtype)
             x_2 = attn_2 @ v_2.transpose(-2, -3)
 
             context_2 = x_2.transpose(1, 2)


### PR DESCRIPTION
## Summary

- Replace hardcoded `.half()` calls with `.to(x.dtype)` in `hydit/modules/attn_layers.py` to preserve the original input tensor's dtype
- Fixes silent precision loss when training with bfloat16 (common on A100/H100 GPUs), where `.half()` forces a downcast from bfloat16 to float16
- Affected locations: `FlashSelfMHAModified.forward()` (2 calls), `FlashCrossMHAModified.forward()` (3 calls), and `CrossAttention.forward()` IP-adapter path (1 call)

## Problem

Several places in the attention layer implementations hardcode `.half()` after QK normalization and softmax operations. This forces the tensor dtype to float16 regardless of the actual training precision. When running in bfloat16 mode, this silently downcasts tensors from bfloat16 to float16, causing:
- Precision loss due to bfloat16 having a larger dynamic range than float16
- Potential numerical instability during training
- Inconsistent dtype handling within the forward pass

## Fix

Replace all `.half()` calls with `.to(x.dtype)`, which dynamically preserves whatever dtype the input tensor `x` uses. This is a backward-compatible change -- when running in float16 mode, `x.dtype` will be `torch.float16` and behavior is identical to before.

## Test plan

- [ ] Verify existing float16 training produces identical results (`.to(x.dtype)` == `.half()` when input is float16)
- [ ] Verify bfloat16 training no longer silently downcasts to float16
- [ ] Verify inference outputs are unchanged for float16 models